### PR TITLE
Rework crawler, add some common Dart conventions.

### DIFF
--- a/lib/analysis.dart
+++ b/lib/analysis.dart
@@ -1,4 +1,12 @@
 library analysis;
 
-export 'src/crawler.dart' show LibraryTuple, SourceCrawler;
-export 'src/resolver.dart' show SourceResolver, SourceResolverImpl;
+import 'dart:io';
+
+import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/src/generated/java_io.dart';
+import 'package:analyzer/src/generated/source_io.dart';
+
+import 'package:path/path.dart' as path;
+
+part 'src/crawler.dart';
+part 'src/resolver.dart';

--- a/lib/src/crawler.dart
+++ b/lib/src/crawler.dart
@@ -1,157 +1,94 @@
-library analysis.src.crawler;
+part of analysis;
 
-import 'dart:collection';
-import 'dart:io';
+class LibraryTuple {
+  final CompilationUnit astUnit;
 
-import 'package:analysis/src/resolver.dart';
+  final String path;
+  final String packageUri;
 
-import 'package:analyzer/src/generated/ast.dart';
-import 'package:analyzer/src/generated/element.dart';
-import 'package:analyzer/src/generated/engine.dart';
-import 'package:analyzer/src/generated/java_io.dart';
-import 'package:analyzer/src/generated/sdk_io.dart' show DirectoryBasedDartSdk;
-import 'package:analyzer/src/generated/source_io.dart';
-import 'package:path/path.dart' as path;
+  String get name {
+    String name;
+    astUnit.directives
+      .where((e) => e is PartOfDirective || e is LibraryDirective)
+      .forEach((e) => name = e is PartOfDirective ? e.libraryName.name : e.name.name);
+    return name;
+  }
+
+  LibraryTuple._(this.astUnit, [this.path, this.packageUri]);
+}
 
 abstract class SourceCrawler implements Function {
-  factory SourceCrawler() => new SourceCrawlerImpl();
+  factory SourceCrawler({
+      bool analyzeFunctionBodies: false,
+      bool includeDefaultPackageRoot: true,
+      List<String> packageRoots,
+      bool preserveComments: false}) => new _SourceCrawler(analyzeFunctionBodies, includeDefaultPackageRoot, packageRoots, preserveComments);
 
   /// Resolves and crawls [path], and all files imported (recursively). Returns
   /// an [Iterable] of all the ASTs parsed.
-  Iterable<CompilationUnit> call(String path);
+  Iterable<LibraryTuple> call(String path);
 }
 
 /// A source code crawler.
-class SourceCrawlerImpl implements SourceCrawler {
-  static final _dartSdk = DirectoryBasedDartSdk.defaultSdk;
-
-  final AnalysisContextImpl _context;
+class _SourceCrawler implements SourceCrawler {
   final SourceResolver _sourceResolver;
 
-  factory SourceCrawlerImpl({
-      bool analyzeFunctionBodies: false,
-      int cacheSize: 256,
-      bool includeDefaultPackageRoot: true,
+  factory _SourceCrawler(
+      bool analyzeFunctionBodies,
+      bool includeDefaultPackageRoot,
       List<String> packageRoots,
-      bool preserveComments: false}) {
+      bool preserveComments) {
     if (packageRoots == null) {
       packageRoots = [Platform.packageRoot];
     }
-    // Configure analysis options.
-    final analysisOptions = new AnalysisOptionsImpl()
-      ..analyzeFunctionBodies = analyzeFunctionBodies
-      ..cacheSize = 256
-      ..preserveComments = preserveComments;
 
     // Create a resolver to use.
     final sourceResolver = new SourceResolver.fromPackageRoots(
         packageRoots, includeDefaultPackageRoot);
 
-    // Create a new analysis context.
-    final context = AnalysisEngine.instance.createAnalysisContext();
-    context.analysisOptions =
-        _dartSdk.context.analysisOptions =
-        analysisOptions;
-
-    // Configure how we can load source files.
-    context.sourceFactory = new SourceFactory([
-      new DartUriResolver(_dartSdk),
-      new FileUriResolver(),
-      sourceResolver.packageUriResolver
-    ]);
-
-    // Return an instance we can use.
-    return new SourceCrawlerImpl._(context, sourceResolver);
+    return new _SourceCrawler._(sourceResolver);
   }
 
-  SourceCrawlerImpl._(this._context, this._sourceResolver);
+  _SourceCrawler._(this._sourceResolver);
 
   /// Crawls, starting at [path], invoking [crawlFile] for each file.
   @override
-  Iterable<LibraryTuple> call(String path) {
-    return crawl(_sourceResolver(path));
+  Iterable<LibraryTuple> call(String entryPointLocation) {
+    return crawl(entryPointLocation);
   }
 
-  /// Crawls the absolute [entryPointFile]
-  Iterable<LibraryTuple> crawl(
-      String entryPointLocation, [
-      bool deep = true]) {
-    final entryPointFile = new JavaFile(entryPointLocation);
-    final source = new FileBasedSource.con1(entryPointFile);
-    final changeSet = new ChangeSet()..addedSource(source);
-    _context.applyChanges(changeSet);
+  Iterable<LibraryTuple> crawl(String entryPointLocation, [bool deep = false]) {
+    final path = _getFileLocation(entryPointLocation);
+    final astUnit = parseDartFile(path);
 
-    final rootLib = _context.computeLibraryElement(source);
-    final astUnit = _context.getResolvedCompilationUnit(source, rootLib);
-    final visitQueue = new Queue<LibraryTuple>()
-      ..add(new LibraryTuple(astUnit,
-          _getPackageUri(entryPointLocation, source),
-          entryPointFile.toString()));
+    var lib = new LibraryTuple._(astUnit, path);
 
     final results = <LibraryTuple>[];
-    while (visitQueue.isNotEmpty) {
-      final visitNext = visitQueue.removeFirst();
-      results.add(visitNext);
-      if (deep) {
-        visitNext.astUnit.directives
-          .where((directive) =>
-            directive.element is ImportElement ||
-            directive.element is ExportElement)
-          .map((directive) => directive.element)
-          .forEach((UriReferencedElement import) {
-            final astUnit = visitSource(visitNext.fileImportedBy, import.uri);
-            visitQueue.add(new LibraryTuple(
-                astUnit,
-                _getPackageUri(import.uri,
-                    new FileBasedSource.con1(new JavaFile(_getFileLocation(
-                        visitNext.fileImportedBy, import.uri)))),
-                visitNext.fileImportedBy));
-          });
-      }
-    }
+    results.add(lib);
+
+    astUnit.directives
+      .where((directive) =>
+        deep ? directive is ExportDirective || directive is PartDirective:
+        directive is ImportDirective || directive is ExportDirective || directive is PartDirective)
+      .forEach((UriBasedDirective import) {
+        final path = _getFileLocation(import.uri.stringValue, lib.path);
+        if(path != null) {
+          results.addAll(this.crawl(path, true));
+        }
+      });
 
     return results;
   }
 
-  String _getFileLocation(String relativeTo, String uri) {
+  String _getFileLocation(String uri, [String relativeTo]) {
     if (uri == null || uri.startsWith('dart:')) {
       return null;
     } else if (uri.startsWith('package:')) {
       return _sourceResolver(uri);
     } else {
-      return path.join(path.dirname(relativeTo), uri);
+      if(relativeTo != null)
+        return path.join(path.dirname(relativeTo), uri);
+      return path.absolute(uri);
     }
   }
-
-  String _getPackageUri(String importUri, Source source) {
-    if (importUri.startsWith('package:') ||
-        importUri.startsWith('dart:')) {
-      return importUri;
-    } else {
-      return _sourceResolver
-        .packageUriResolver
-        .restoreAbsolute(source)
-        .toString();
-    }
-  }
-
-  CompilationUnit visitSource(String relativeTo, String uri) {
-    final path = _getFileLocation(relativeTo, uri);
-    if (path == null) {
-      return new CompilationUnit(null, null, const [], const [], null);
-    } else {
-      return crawl(path, false).first.astUnit;
-    }
-  }
-}
-
-class LibraryTuple {
-  final CompilationUnit astUnit;
-  final String fileImportedBy;
-  final String packageUri;
-
-  LibraryTuple(this.astUnit, [this.packageUri, this.fileImportedBy]);
-
-  @override
-  String toString() => 'Library {${packageUri}}';
 }

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -1,9 +1,4 @@
-library analysis.src.resolver;
-
-import 'dart:io';
-
-import 'package:analyzer/src/generated/java_io.dart';
-import 'package:analyzer/src/generated/source_io.dart';
+part of analysis;
 
 /// A source code file resolver.
 class SourceResolver implements Function {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,9 @@ name: analysis
 description: A set of utility classes to make common use cases of using the Dart analyzer.
 version: 0.0.1-alpha.1
 homepage: https://github.com/matanlurey/analysis
-author: Matan Lurey <matanl@google.com>
+authors:
+- Matan Lurey <matanl@google.com>
+- Michael Bullington <mikebullingtn@gmail.com>
 dependencies:
   analyzer: ">=0.25.0+1 <0.26.0"
 dev_dependencies:

--- a/test/crawler_test.dart
+++ b/test/crawler_test.dart
@@ -1,6 +1,6 @@
 library analysis.test.resolver_test;
 
-import 'package:analysis/src/crawler.dart';
+import 'package:analysis/analysis.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -10,13 +10,12 @@ void main() {
     test('can run on test_data.dart', () async {
       final librariesLoaded =
           sourceCrawler('package:analysis/src/test_data/test_data.dart')
-            .map((LibraryTuple library) => library.packageUri)
+            .map((LibraryTuple library) => library.name)
             .toList();
 
       expect(librariesLoaded, [
-        'package:analysis/src/test_data/test_data.dart',
-        'dart:collection',
-        'package:analysis/src/test_data/test_import.dart'
+        'test_data',
+        'test_import'
       ]);
     });
   });

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -2,7 +2,7 @@ library analysis.test.resolver_test;
 
 import 'dart:io';
 
-import 'package:analysis/src/resolver.dart';
+import 'package:analysis/analysis.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -13,7 +13,7 @@ void main() {
       final path = sourceResolver('package:analysis/src/resolver.dart');
       expect(path, endsWith('resolver.dart'));
       final String file = await new File(path).readAsString();
-      expect(file, startsWith('library analysis.src.resolver;'));
+      expect(file, startsWith('part of analysis;'));
     });
   });
 }


### PR DESCRIPTION
Hello,

I really like the analysis lib and the idea of creating higher-level abstractions on top of analyzer. I couldn't get your crawler to work, so I more or less rewrote it.

Improvements over the old crawler is that it works (in my case, might have always worked for you), it handles parts properly, and the code is easier to read by using some of the non-generated helpers in the analyzer library. It also allows you to get the dot name of the library.

I'm sorry if it doesn't meet all of your use cases, if you are open to accepting this PR, I'd be happy to talk to you and add them back.

I also adjusted little things to follow more Dart-like conventions, like the use of parts with the library. crawler.dart and resolver.dart are no longer separate libraries, but part of the same analysis library.

I currently had to adapt this library for my own use cases, and I hope we can merge these improvements upstream.
